### PR TITLE
Add initial README, LICENSE, and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,161 @@
+# Code of Conduct (DRAFT)
+
+**Status:** Draft for Community Input
+
+This is a **working draft** of the OC-AGI Code of Conduct. We invite all community members to review, discuss, and help shape this document. Nothing here is final — this is the beginning of a collective conversation about the kind of community we want to build.
+
+## Purpose
+
+The Open Collective AGI community is committed to providing a welcoming, inclusive, and respectful environment for everyone who shares our mission of building AGI as a public good.
+
+This Code of Conduct outlines our expectations for participant behavior and the consequences for unacceptable conduct.
+
+## Our Values
+
+We are building a community based on:
+- **Respect** for all people, perspectives, and backgrounds
+- **Transparency** in communication and decision-making
+- **Inclusivity** that welcomes diverse voices and experiences
+- **Good faith** engagement focused on collective progress
+- **Human dignity** as a non-negotiable principle
+
+## Expected Behavior
+
+We expect all community members to:
+
+### Be Respectful
+- Treat others with dignity and consideration
+- Respect differing opinions, viewpoints, and experiences
+- Give and receive constructive feedback gracefully
+- Acknowledge when you don't know something
+
+### Be Inclusive
+- Welcome newcomers and help them feel included
+- Use inclusive language
+- Be mindful of cultural and linguistic differences
+- Create space for voices that are often marginalized
+
+### Be Constructive
+- Focus on ideas and solutions, not personal attacks
+- Disagree without being disagreeable
+- Assume good intentions unless proven otherwise
+- Contribute to discussions in ways that move the collective forward
+
+### Be Transparent
+- Be honest about your motivations and affiliations
+- Acknowledge conflicts of interest
+- Share credit appropriately
+- Admit mistakes and learn from them
+
+### Be Responsible
+- Take ownership of your words and actions
+- Consider the impact of your contributions
+- Follow through on commitments
+- Help maintain a safe and welcoming environment
+
+## Unacceptable Behavior
+
+The following behaviors are unacceptable in our community:
+
+### Harassment and Abuse
+- Threats of violence or violent language
+- Personal attacks or insults
+- Discriminatory jokes or language
+- Unwelcome sexual attention or advances
+- Posting private information without consent (doxxing)
+- Intimidation or stalking
+
+### Disruptive Conduct  
+- Trolling or deliberately inflammatory comments
+- Sustained disruption of discussions
+- Spreading misinformation in bad faith
+- Spam or excessive self-promotion
+
+### Violations of Trust
+- Plagiarism or taking credit for others' work
+- Misrepresenting affiliations or credentials
+- Deliberately undermining the collective's mission
+- Using the community for personal gain at the expense of others
+
+### Discrimination
+- Discrimination based on race, ethnicity, nationality, religion, gender identity, sexual orientation, age, disability, or any other protected characteristic
+
+## Scope
+
+This Code of Conduct applies to:
+- All OC-AGI repositories and GitHub spaces
+- GitHub Discussions and Issues
+- Future community platforms (Discord, forums, etc.)
+- Any space where you represent OC-AGI
+- Events and gatherings (virtual or in-person)
+
+## Enforcement
+
+### If You Experience or Witness Unacceptable Behavior
+
+**During Inception Phase:**
+- Report via GitHub Issue (with "Code of Conduct" label)
+- Contact repository maintainers directly
+- Document the incident with as much detail as possible
+
+**What Happens Next:**
+- Reports will be reviewed promptly
+- Confidentiality will be maintained when possible
+- Appropriate action will be taken based on severity
+
+### Possible Consequences
+
+Depending on the severity and frequency of violations:
+
+1. **Warning:** Private communication explaining the violation
+2. **Temporary Ban:** Temporary removal from community spaces
+3. **Permanent Ban:** Permanent removal from all community spaces
+4. **Public Statement:** In cases of severe or repeated violations
+
+### Appeal Process
+
+*(To be developed as governance structures are established)*
+
+## Questions for Community Input
+
+As this is a **draft**, we specifically need input on:
+
+1. **Enforcement:** Who should handle reports? How do we ensure fairness?
+2. **Appeals:** What should the appeal process look like?
+3. **Mediation:** Should we have a mediation step before enforcement?
+4. **Transparency:** How much should be public vs. private in enforcement?
+5. **Cultural Sensitivity:** Are we missing important cultural considerations?
+6. **Edge Cases:** What scenarios need clearer guidance?
+
+## How to Contribute to This Draft
+
+We want your input! You can:
+- Open a [Discussion](../../discussions) about specific sections
+- Submit an [Issue](../../issues) with suggested changes
+- Share examples from other communities that work well
+- Identify gaps or ambiguities that need clarification
+
+**This Code of Conduct should reflect our collective values, not just one person's perspective.**
+
+## Acknowledgments
+
+This draft draws inspiration from:
+- The Contributor Covenant
+- The Django Code of Conduct  
+- The Rust Code of Conduct
+- Various open-source community guidelines
+
+We acknowledge the many communities who have thoughtfully developed conduct standards before us.
+
+## Status: Living Document
+
+Even after this moves from draft to active status, we expect it to evolve. A good Code of Conduct reflects the lived experience of the community it serves.
+
+---
+
+**Let's build a community that reflects the world we want AGI to serve.**
+
+---
+
+<!-- AI: CC2:Claude Sonnet 4.5 (Cursor-MCP) -->
+

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,144 @@
+# About Licensing
+
+**Status:** Under Discussion
+
+We're deciding which license is most appropriate for the OC-AGI organization documents. This document outlines the options and helps clarify what we're trying to achieve.
+
+## What We Want to Achieve
+
+For our founding documents (manifesto, privacy guide, README), we want:
+- ✅ Anyone can read and share them freely
+- ✅ Anyone can adapt them for their own use (with attribution)
+- ✅ Derivatives should remain open (copyleft principle)
+- ✅ Clear that this is open, collective work
+- ❓ Should commercial use be allowed?
+- ❓ What about future code/software projects?
+
+## License Options
+
+### Creative Commons (for Documents/Content)
+
+**Best for:** Documents, manifestos, educational content, writings
+
+**CC-BY-SA 4.0** (Attribution-ShareAlike)
+- ✅ Anyone can share and adapt
+- ✅ Must give credit
+- ✅ Derivatives must use same license (keeps it open)
+- ✅ Allows commercial use
+- 🎯 **Most similar to software copyleft licenses**
+- 📌 Used by: Wikipedia, many open educational resources
+
+**CC-BY 4.0** (Attribution only)
+- ✅ Anyone can share and adapt
+- ✅ Must give credit  
+- ⚠️ Derivatives can be closed/proprietary
+- ✅ Allows commercial use
+
+**CC-BY-NC-SA 4.0** (Non-Commercial + ShareAlike)
+- ✅ Same as CC-BY-SA but...
+- ❌ No commercial use allowed
+- ⚠️ Can limit spreading of ideas
+
+### Software Licenses (for Code/Software)
+
+**Best for:** Actual code, software projects, technical implementations
+
+These are what you mentioned: Apache 2.0, MIT, EPL 2.0
+
+**MIT License**
+- ✅ Very permissive
+- ✅ Simple and well-understood
+- ⚠️ Allows proprietary derivatives
+- 📌 Used by: React, Node.js, many JS libraries
+
+**Apache License 2.0**
+- ✅ Permissive like MIT
+- ✅ Includes patent grants (important for AI/ML)
+- ✅ More legally robust
+- ⚠️ Allows proprietary derivatives
+- 📌 Used by: Android, Kubernetes, TensorFlow
+
+**Eclipse Public License 2.0**
+- ✅ Weak copyleft (only modifications must be open)
+- ✅ Includes patent provisions
+- ✅ Good for commercial/corporate participation
+- 📌 Used by: Eclipse IDE, various enterprise projects
+
+**GNU GPL v3** (not mentioned, but worth considering)
+- ✅ Strong copyleft (all derivatives must be open)
+- ✅ Prevents proprietary forks
+- ✅ Includes patent grants
+- ⚠️ Can discourage some corporate contributors
+- 📌 Used by: Linux kernel, many GNU projects
+
+**GNU AGPL v3** (strongest copyleft)
+- ✅ Like GPL but closes "SaaS loophole"
+- ✅ If you use it as a web service, you must share code
+- ✅ Prevents proprietary cloud services built on open code
+- ⚠️ More restrictive, limits some use cases
+- 📌 Used by: Some open-source AI projects wanting to prevent corporate exploitation
+
+## Key Distinction
+
+**Documents vs. Code:**
+- Use **Creative Commons** for documents, writings, educational content
+- Use **Software Licenses** for actual code and technical implementations
+
+## Recommendation for OC-AGI
+
+### For Current Documents (Manifesto, Privacy Guide, README)
+**Suggested: CC-BY-SA 4.0**
+
+Why?
+- Keeps documents open and freely shareable
+- Requires derivatives to remain open (copyleft)
+- Allows anyone to adapt for their context
+- Widely understood and respected
+- Philosophical alignment with "collective" values
+
+### For Future Software/Code Projects
+**Suggested: Apache 2.0 or AGPL v3** (depending on goals)
+
+**Choose Apache 2.0 if:**
+- You want maximum participation and adoption
+- You're okay with companies building proprietary tools on top
+- You want to be pragmatic about corporate involvement
+
+**Choose AGPL v3 if:**
+- You want to prevent companies from taking code and closing it
+- You want to ensure derivative works remain open
+- You prioritize collective ownership over rapid adoption
+
+## What About Mixing Licenses?
+
+You can (and probably should) use different licenses for different parts:
+- **Documents:** CC-BY-SA 4.0
+- **Code repositories:** Apache 2.0 or AGPL v3 (decided per project)
+- **Datasets:** CC-BY-SA 4.0 or specific data licenses
+
+This is common in open-source organizations.
+
+## Questions to Decide
+
+1. Should people be able to use our manifesto commercially (e.g., print it in a book they sell)?
+   - If yes: CC-BY-SA 4.0
+   - If no: CC-BY-NC-SA 4.0
+
+2. For future code, do we want to prevent proprietary forks?
+   - If yes: Consider GPL/AGPL
+   - If no: Apache 2.0 or MIT
+
+3. Is patent protection important? (probably yes for AGI work)
+   - If yes: Apache 2.0 or GPL/AGPL (include patent clauses)
+
+## Let's Discuss
+
+This is a collective decision. Share your thoughts:
+- Open a [Discussion](../../discussions) about licensing
+- What values should our license reflect?
+- What uses should we encourage or prevent?
+
+---
+
+<!-- AI: CC2:Claude Sonnet 4.5 (Cursor-MCP) -->
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,178 @@
-# README
+# Open Collective AGI (OC-AGI)
 
-.. in progress.
+> Building transparent, inclusive, open-source AGI for the benefit of all humanity
+
+## 🌍 Overview
+
+**Open Collective AGI** is a global initiative to ensure that artificial general intelligence (AGI) is developed as a public good, not a private asset. We believe that the future of AGI must be shaped by a diverse collective of people, not solely by powerful corporations and states.
+
+This repository contains the foundational documents that define our mission, values, and principles.
+
+---
+
+## 📜 Founding Documents
+
+Our organization is built upon two core documents:
+
+### 1. [Open Collective AGI Manifesto](open_collective_agi_manifesto.md)
+Our vision for creating an open-source, decentralized AGI project governed by a global, diverse collective of verified humans. This document outlines:
+- Why centralized AGI development poses risks
+- Our mission for transparent, inclusive, non-profit AGI
+- Key principles: global diversity, digital identity, transparent governance, and open collaboration
+
+### 2. [AI Privacy and Data Awareness](ai_privacy.md)
+A practical guide to understanding and protecting personal data in the age of AI. This document explores:
+- The risks of unchecked data collection
+- Real-world examples of data exploitation
+- How AGI could amplify these risks
+- Actionable steps for individuals to share data wisely
+
+**We encourage everyone to read both documents to understand our foundation and approach.**
+
+---
+
+## 🎯 Our Vision
+
+We envision a future where AGI is:
+- **A public good** accessible to all, not controlled by a few
+- **Transparent and open-source** in its development and operation
+- **Inclusive and diverse** reflecting all cultures, languages, and backgrounds
+- **Respectful of human dignity** with rights and ethics embedded from day one
+
+AGI may be 10–20 years away, but without early action, open-source efforts will lag behind corporate development. We must lay the groundwork today to preserve digital democracy and ensure AGI serves humanity, not just shareholders.
+
+---
+
+## 🤝 How to Get Involved
+
+OC-AGI is in its **inception phase**. We are building the foundations of this collective and welcome contributions from those who share our values and vision.
+
+### We Value Quality Over Quantity
+
+This is a serious, long-term initiative. We seek contributors who:
+- ✅ Align with our principles of transparency, inclusivity, and human dignity
+- ✅ Contribute constructively to discussions and development
+- ✅ Respect diverse perspectives and engage in good faith
+- ✅ Are committed to building AGI as a public good
+
+### Ways to Contribute
+
+**Right now, you can:**
+
+1. **Review and Discuss Our Documents**
+   - Open [GitHub Discussions](../../discussions) to share thoughts on the manifesto and privacy document
+   - Suggest improvements or clarifications
+   - Help refine our principles and approach
+
+2. **Propose Amendments**
+   - Submit [Issues](../../issues) with suggested changes to our founding documents
+   - Participate in discussions about amendments
+   - Help us evolve these documents thoughtfully
+
+3. **Share Your Expertise**
+   - Tell us about your background and how you could contribute
+   - Propose areas where you could lead or collaborate
+   - Help identify gaps in our approach
+
+4. **Spread Awareness**
+   - Share our manifesto with others who care about open, ethical AGI
+   - Help us build a diverse, global community
+
+### Community Standards
+
+We are committed to maintaining a respectful, productive environment. Contributors are expected to:
+- Engage respectfully and constructively
+- Focus on ideas and solutions, not personal attacks  
+- Support our mission of inclusive, transparent AGI development
+- Act in good faith toward the collective good
+
+**Note**: As we establish governance structures, we will develop formal contribution guidelines and community standards. For now, we rely on shared values and mutual respect.
+
+---
+
+## 📍 Current Status: Inception Phase
+
+**Where we are:**
+- ✅ Founding documents established
+- ✅ Organization created and made public
+- 🔄 Building initial community
+- 🔄 Developing governance framework
+
+**What's next:**
+- Define formal governance structure
+- Establish decision-making processes
+- Build core team and advisory groups
+- Identify first concrete initiatives and projects
+
+This is the beginning. We're laying the foundations carefully and deliberately.
+
+---
+
+## 🗺️ Roadmap
+
+Our journey will unfold in phases:
+
+### Phase 1: Foundation (Current)
+- Establish founding documents ✅
+- Build initial community 🔄
+- Define governance framework 🔜
+- Create contribution guidelines 🔜
+
+### Phase 2: Governance & Structure
+- Implement decision-making processes
+- Establish membership structures
+- Form working groups and committees
+- Develop detailed roadmaps
+
+### Phase 3: Research & Planning
+- Survey existing open-source AI/AGI efforts
+- Identify technical requirements and challenges
+- Build partnerships with aligned organizations
+- Secure sustainable funding models
+
+### Phase 4: Development
+- Launch technical initiatives
+- Develop open infrastructure
+- Create shared datasets and models
+- Build community tools and platforms
+
+**Timeline**: These phases will take years, not months. We're committed to doing this right, not fast.
+
+---
+
+## 📬 Contact & Communication
+
+**Primary communication channel:** This GitHub repository
+
+- **Questions?** Open a [Discussion](../../discussions)
+- **Suggestions?** Create an [Issue](../../issues)  
+- **Want to contribute?** Introduce yourself in Discussions
+
+We intentionally use GitHub as our primary platform to keep all communication open, transparent, and archived. This aligns with our commitment to transparency and inclusive participation.
+
+*Note: We are considering additional community platforms (Discord, forums, etc.) and will announce them here as they are established.*
+
+---
+
+## 🌱 Join the Movement
+
+This is bigger than any one person or organization. AGI will shape the future of humanity — it must be shaped **by** humanity.
+
+Whether you're an engineer, researcher, activist, educator, or simply someone who believes AGI should serve all people, not just the powerful — you have a role to play.
+
+**Start by reading our [Manifesto](open_collective_agi_manifesto.md) and [Privacy Document](ai_privacy.md), then join the conversation.**
+
+Together, we can build a future where AGI is a force for collective good.
+
+---
+
+## 📄 License
+
+The documents in this repository are currently under discussion for appropriate licensing. See [LICENSE.md](LICENSE.md) for details on the licensing options being considered.
+
+---
+
+*Open Collective AGI — A global movement for transparent, inclusive, open-source AGI*
+
+---
+<!-- AI: CC2:Claude Sonnet 4.5 (Cursor-MCP) -->


### PR DESCRIPTION
Closes #9

## Summary

This PR adds the foundational repository documentation:

### README.md
- Comprehensive overview of OC-AGI mission and vision
- Links to founding documents
- Clear contribution guidelines and pathways
- Roadmap showing current inception phase and future plans
- Communication channels and community standards

### LICENSE.md
- Discussion of licensing options for documents (Creative Commons)
- Discussion of licensing options for future code (Apache, GPL, AGPL, etc.)
- Recommendations with reasoning
- Framework for community decision-making

### CODE_OF_CONDUCT.md
- Draft code of conduct inviting community input
- Expected and unacceptable behaviors
- Enforcement guidelines (to be developed further)
- Questions for community discussion

## Review Process
- **CC2** (Claude Sonnet 4.5, Cursor-MCP) created initial content
- **SA** (Claude Code v.2.0.27, CLI) performed pre-commit review
- Human operator approved content
- Files renamed to standard GitHub conventions

## Notes
- LICENSE.md is a discussion document, not a final license choice
- CODE_OF_CONDUCT.md is marked as draft and invites input
- README has minor markdown lint warnings (formatting style choices)

Co-authored by CC2 and SA with human oversight.